### PR TITLE
Turn off keyboard suggestions

### DIFF
--- a/app/src/main/java/org/eyeseetea/uicapp/presentation/views/EditCard.java
+++ b/app/src/main/java/org/eyeseetea/uicapp/presentation/views/EditCard.java
@@ -23,6 +23,7 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.content.res.TypedArray;
 import android.graphics.Typeface;
+import android.text.InputType;
 import android.util.AttributeSet;
 import android.widget.EditText;
 
@@ -73,7 +74,17 @@ public class EditCard extends EditText{
                 a.recycle();
             }
         }
+        disableTextSuggestions();
     }
+
+    private void disableTextSuggestions() {
+        //InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS does not seem to work as expected on all keyboards
+        // whereas InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD has the drawback that it also
+        // disables toggling the language in the keyboard and the swipe gesture to add the text.
+        setInputType(this.getInputType() | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+                | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+    }
+
 
     /**
      * Gets the mDimension attribute value.

--- a/app/src/main/res/layout/date_of_birth_row.xml
+++ b/app/src/main/res/layout/date_of_birth_row.xml
@@ -79,7 +79,6 @@
             android:id="@+id/twin_dropdown"
             android:layout_width="match_parent"
             android:layout_height="@dimen/edit_text_height"
-            android:inputType="textNoSuggestions"
             android:textSize="@dimen/spinner_text_size"
             android:textColor="@color/date_text"
             android:textColorHint="@color/hint_color"

--- a/app/src/main/res/layout/district_of_birth_row.xml
+++ b/app/src/main/res/layout/district_of_birth_row.xml
@@ -22,7 +22,6 @@
         android:id="@+id/district_dropdown"
         android:layout_width="match_parent"
         android:layout_height="@dimen/edit_text_height"
-        android:inputType="textNoSuggestions"
         android:textSize="@dimen/title_text_size"
         android:textColor="@color/district_text"
         android:hint="@string/district_hint"

--- a/app/src/main/res/layout/mother_first_name_row.xml
+++ b/app/src/main/res/layout/mother_first_name_row.xml
@@ -42,7 +42,6 @@
         android:id="@+id/mother_edit_text"
         android:layout_width="match_parent"
         android:layout_height="@dimen/edit_text_height"
-        android:inputType="textNoSuggestions"
         android:textColor="@color/mother_text"
         android:textSize="@dimen/title_text_size"
         android:hint="@string/mother_hint"

--- a/app/src/main/res/layout/surname_row.xml
+++ b/app/src/main/res/layout/surname_row.xml
@@ -22,7 +22,6 @@
         android:id="@+id/surname_edit_text"
         android:layout_width="match_parent"
         android:layout_height="@dimen/edit_text_height"
-        android:inputType="textNoSuggestions"
         android:textSize="@dimen/title_text_size"
         android:textColor="@color/surname_text"
         android:textColorHint="@color/hint_color"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #72               
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: Feature/turn off keyboard suggestions Target: Development
**bugshaker-android**: 
       Origin: development  

### :tophat: What is the goal?

turn off keyboard suggestions

### :memo: How is it being implemented?

After reviewing many forums pages I have found the solution, assigning textNoSuggestions and textVisiblePassword as input type.

InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS does not seem to work as expected on all keyboards whereas InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD has the drawback that it also disables toggling the language in the keyboard and the swipe gesture to add the text.

I have deleted textNoSuggestions assignment from layouts where has no sense and where has sense is assigned from Editcard custom view.
 
### :boom: How can it be tested?

**UseCase 1**:  for mother name and surname text suggestion should not appear

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-