### PR TITLE
Add default item and order spinners by code

### DIFF
--- a/app/src/main/java/org/eyeseetea/uicapp/presentation/ScrollingActivity.java
+++ b/app/src/main/java/org/eyeseetea/uicapp/presentation/ScrollingActivity.java
@@ -42,7 +42,13 @@ import org.eyeseetea.uicapp.presentation.views.EditCard;
 import org.eyeseetea.uicapp.presentation.views.TextCard;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 import io.fabric.sdk.android.Fabric;
 
@@ -115,12 +121,12 @@ public class ScrollingActivity extends AppCompatActivity {
     private void refreshCode() {
         TextCard textView = viewHolders.code;
 
-        Client client =  getClient();
+        Client client = getClient();
 
         CodeResult codeResult = codeGenerator.generateCode(client);
 
         if (codeResult.isValid()) {
-            textView.setText(((CodeResult.Success)codeResult).getCode());
+            textView.setText(((CodeResult.Success) codeResult).getCode());
             viewHolders.codeButton.setEnabled(true);
         } else {
             textView.setText(getApplicationContext().getString(R.string.code_invalid));
@@ -132,9 +138,10 @@ public class ScrollingActivity extends AppCompatActivity {
         String mother = getStringFromSharedPreference(R.string.shared_key_mother, DEFAULT_VALUE);
         String surname = getStringFromSharedPreference(R.string.shared_key_surname, DEFAULT_VALUE);
 
-        String district = getStringFromSharedPreference(R.string.shared_key_district, DEFAULT_VALUE);
+        String district = getStringFromSharedPreference(R.string.shared_key_district,
+                DEFAULT_VALUE);
 
-        if (district.equals(getString(R.string.default_district))){
+        if (district.equals(getString(R.string.default_district))) {
             district = DEFAULT_VALUE;
         }
 
@@ -206,10 +213,19 @@ public class ScrollingActivity extends AppCompatActivity {
 
     private void initDropDown(final Spinner spinner, final int keyId, int list_key,
             int id_default) {
-        String value = getStringFromSharedPreference(keyId, getString(id_default));
+        String defaultValue = getString(id_default);
+        String value = getStringFromSharedPreference(keyId, defaultValue);
+
+        List<String> itemsList = new ArrayList<>(
+                Arrays.asList(getResources().getStringArray(list_key)));
+
+        Collections.sort(itemsList);
+
+        itemsList.add(0, defaultValue);
+
         ArrayAdapter<String> districtsList = new ArrayAdapter<String>(this,
-                android.R.layout.simple_spinner_dropdown_item,
-                getResources().getStringArray(list_key));
+                android.R.layout.simple_spinner_dropdown_item, itemsList);
+
         spinner.setAdapter(districtsList);
         if (!value.equals("")) {
             for (int i = 0; i < spinner.getCount(); i++) {
@@ -304,7 +320,8 @@ public class ScrollingActivity extends AppCompatActivity {
             public void onTextChanged(CharSequence s, int start, int before, int count) {
                 //Ignore the clear fields validation.
                 putStringInSharedPreference(String.valueOf(s), keyId);
-                if (!codeGenerator.isValidMotherName(String.valueOf(s)) && isValidationErrorActive) {
+                if (!codeGenerator.isValidMotherName(String.valueOf(s))
+                        && isValidationErrorActive) {
                     editText.setError(getApplicationContext().getString(errorId));
                 } else {
                     editText.setError(null);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,14 +33,12 @@
     <string name="mother_info">"There's a user convention for certain situations for filling in this field (mother's name):\n  \n If mother's name is still unknown please write XX \n  \n If client refuses to provide mother's name, then please introduce ZZ"    </string>
     <string name="date_of_birth_info">"There's a user convention for certain situations for filling in this field (date of birth): \n  \n If client knows age/year of birth/school year, then date of birth is 15 June, estimated year. \n  \n If client knows year and month, then date of birth is 15 of the given month and given year."    </string>
     <string-array name="twin_list">
-        <item>@string/default_twin</item>
         <item>1</item>
         <item>2</item>
         <item>3</item>
         <item>4</item>
     </string-array>
     <string-array name="district_list">
-        <item>@string/default_district</item>
         <item>Beitbridge</item>
         <item>Bikita</item>
         <item>Bindura</item>

--- a/app/src/malawi/res/values/strings.xml
+++ b/app/src/malawi/res/values/strings.xml
@@ -4,7 +4,6 @@
     <string name="mother_title">"Mother's first name"</string>
     <string name="surname_title">"Client's surname"</string>
     <string-array name="district_list">
-        <item>@string/default_district</item>
         <item>Chitipa</item>
         <item>Karonga</item>
         <item>Rumphi</item>

--- a/app/src/zambia/res/values/strings.xml
+++ b/app/src/zambia/res/values/strings.xml
@@ -5,7 +5,6 @@
     <string name="mother_error">"The field needs at least three characters"</string>
     <string name="surname_error">"The field needs at least three characters"</string>
     <string-array name="district_list">
-        <item>@string/default_district</item>
         <item>Beitbridge</item>
         <item>Bikita</item>
         <item>Bindura</item>

--- a/app/src/zimbabwe/res/values/strings.xml
+++ b/app/src/zimbabwe/res/values/strings.xml
@@ -3,7 +3,6 @@
     <string name="mother_title">"Mother's first name"</string>
     <string name="surname_title">"Client's surname"</string>
     <string-array name="district_list">
-        <item>@string/default_district</item>
         <item>Beitbridge</item>
         <item>Bikita</item>
         <item>Bindura</item>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #73                
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: feature/alphabetically_order_districts Target: Development
**bugshaker-android**: 
       Origin: development  

### :tophat: What is the goal?

alphabetically order districts 

### :memo: How is it being implemented?

Until now the default item (Select ...) and the order were adding from string list resources. I have modified the code and now the order and default item are added dynamically from code.
 
### :boom: How can it be tested?

**UseCase 1**:  open app and dropdowns should be ordered alphabetically

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-