### PR TITLE
solve appearance mismatch with previous version in font type

### DIFF
--- a/app/src/main/java/org/eyeseetea/uicapp/presentation/views/EditCard.java
+++ b/app/src/main/java/org/eyeseetea/uicapp/presentation/views/EditCard.java
@@ -81,7 +81,7 @@ public class EditCard extends EditText{
         //InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS does not seem to work as expected on all keyboards
         // whereas InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD has the drawback that it also
         // disables toggling the language in the keyboard and the swipe gesture to add the text.
-        setInputType(this.getInputType() | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+        setInputType(InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
                 | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #80             
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: bug/fix_appearance
**bugshaker-android**: 
       Origin: developement

### :tophat: What is the goal?

Fix font variation since last version to now

### :memo: How is it being implemented?

Given that the font variation appeared with the textSuggestions suppresion I directly went to the EditCard class where the InputType was programatically modified and removed the getInputType() from there. It's the only way I found for restoring the behaviour keeping the suggestion removal one.

### :boom: How can it be tested?

**UseCase 1**: Open the app and any edit text whould render exactly as previous version

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-